### PR TITLE
Implement small screen overlay

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Umbrella from "./components/Umbrella";
 import Mountain from "./components/Mountain";
 import EcoCycleNav from "./components/EcoCycleNav.js";
 import Marina from "./components/Marina.js";
+import SmallScreenOverlay from "./components/SmallScreenOverlay";
 
 import { useLocation } from "react-router-dom";
 function Layout() {
@@ -33,6 +34,7 @@ function App() {
   const location = useLocation();
   return (
     <div>
+      <SmallScreenOverlay />
       <Layout></Layout>
       <Routes location={location} key={location.pathname}>
         <Route index element={<Home />} />

--- a/src/components/SmallScreenOverlay.css
+++ b/src/components/SmallScreenOverlay.css
@@ -1,0 +1,22 @@
+.small-screen-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: black;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 3000;
+  text-align: center;
+  padding: 1rem;
+}
+
+.small-screen-overlay img {
+  width: 4rem;
+  height: auto;
+  margin-bottom: 1rem;
+}

--- a/src/components/SmallScreenOverlay.js
+++ b/src/components/SmallScreenOverlay.js
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from "react";
+import "./SmallScreenOverlay.css";
+
+const SmallScreenOverlay = () => {
+  const [isSmall, setIsSmall] = useState(false);
+
+  useEffect(() => {
+    const checkScreen = () => setIsSmall(window.innerWidth < 768);
+    checkScreen();
+    window.addEventListener("resize", checkScreen);
+    return () => window.removeEventListener("resize", checkScreen);
+  }, []);
+
+  if (!isSmall) return null;
+  return (
+    <div className="small-screen-overlay">
+      <img src="/img/logo_w.svg" alt="logo" />
+      <p>You need a bigger screen to view this website.</p>
+    </div>
+  );
+};
+
+export default SmallScreenOverlay;


### PR DESCRIPTION
## Summary
- add `SmallScreenOverlay` component and styles
- inject the overlay in `App`
- remove Apple icon and use the site logo instead

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688367ea5bdc8324884e66faaae6c766